### PR TITLE
feat: add adjustable font size

### DIFF
--- a/app/src/main/java/vadimerenkov/aucards/MainActivity.kt
+++ b/app/src/main/java/vadimerenkov/aucards/MainActivity.kt
@@ -18,13 +18,14 @@ class MainActivity : AppCompatActivity() {
 		super.onCreate(savedInstanceState)
 		enableEdgeToEdge()
 		setContent {
-			val app = this.application as AucardsApplication
-			val theme_string by app.settings.themeSetting.collectAsState("why are we here")
-			val isDarkTheme = when (theme_string) {
-				Theme.LIGHT.name -> false
-				Theme.DARK.name -> true
-				else -> isSystemInDarkTheme()
-			}
+                        val app = this.application as AucardsApplication
+                        val theme_string by app.settings.themeSetting.collectAsState("why are we here")
+                        val fontScale by app.settings.fontScale.collectAsState(1f)
+                        val isDarkTheme = when (theme_string) {
+                                Theme.LIGHT.name -> false
+                                Theme.DARK.name -> true
+                                else -> isSystemInDarkTheme()
+                        }
 
 			val locales = getApplicationLocales()
 			setApplicationLocales(locales)
@@ -36,11 +37,12 @@ class MainActivity : AppCompatActivity() {
 				)
 			}
 
-			AucardsTheme(
-				darkTheme = isDarkTheme
-			) {
-				MainNavHost(isDarkTheme)
-			}
+                        AucardsTheme(
+                                darkTheme = isDarkTheme,
+                                fontScale = fontScale
+                        ) {
+                                MainNavHost(isDarkTheme)
+                        }
 		}
 	}
 }

--- a/app/src/main/java/vadimerenkov/aucards/screens/SettingsScreen.kt
+++ b/app/src/main/java/vadimerenkov/aucards/screens/SettingsScreen.kt
@@ -357,18 +357,36 @@ fun SettingsScreen(
 							modifier = Modifier
 							.padding(top = 8.dp)
 						)
-						DropdownSetting(
-							options = Language.entries.map { it.uiText }.sorted(),
-							icon = R.drawable.language,
-							description = stringResource(R.string.language),
-							onOptionChosen = { viewModel.saveLanguageSetting(it) },
-							chosenOption = stringResource(state.language.uiText)
-						)
-						state.language.translator?.let { it ->
-							Text(
-								text = stringResource(it),
-								color = MaterialTheme.colorScheme.primary,
-									style = MaterialTheme.typography.bodyMedium,
+                                                DropdownSetting(
+                                                        options = Language.entries.map { it.uiText }.sorted(),
+                                                        icon = R.drawable.language,
+                                                        description = stringResource(R.string.language),
+                                                        onOptionChosen = { viewModel.saveLanguageSetting(it) },
+                                                        chosenOption = stringResource(state.language.uiText)
+                                                )
+                                                DropdownSetting(
+                                                        options = listOf(R.string.small, R.string.medium, R.string.large),
+                                                        description = stringResource(R.string.font_size),
+                                                        onOptionChosen = {
+                                                                val scale = when (it) {
+                                                                        R.string.small -> 0.85f
+                                                                        R.string.medium -> 1f
+                                                                        R.string.large -> 1.15f
+                                                                        else -> 1f
+                                                                }
+                                                                viewModel.saveFontScaleSetting(scale)
+                                                        },
+                                                        chosenOption = when (state.fontScale) {
+                                                                in 0f..0.9f -> stringResource(R.string.small)
+                                                                in 0.9f..1.1f -> stringResource(R.string.medium)
+                                                                else -> stringResource(R.string.large)
+                                                        }
+                                                )
+                                                state.language.translator?.let { it ->
+                                                        Text(
+                                                                text = stringResource(it),
+                                                                color = MaterialTheme.colorScheme.primary,
+                                                                        style = MaterialTheme.typography.bodyMedium,
 									modifier = Modifier
 										.padding(top = 8.dp)
 										.align(Alignment.End)

--- a/app/src/main/java/vadimerenkov/aucards/settings/Keys.kt
+++ b/app/src/main/java/vadimerenkov/aucards/settings/Keys.kt
@@ -2,8 +2,9 @@ package vadimerenkov.aucards.settings
 
 object Keys {
 	const val THEME_STRING = "theme"
-	const val BRIGHTNESS_STRING = "brightness"
-	const val LANDSCAPE_STRING = "landscape"
-	const val SOUND_STRING = "play_sound"
-	const val RINGTONE_URI = "ringtone_uri"
+        const val BRIGHTNESS_STRING = "brightness"
+        const val LANDSCAPE_STRING = "landscape"
+        const val SOUND_STRING = "play_sound"
+        const val RINGTONE_URI = "ringtone_uri"
+        const val FONT_SCALE_STRING = "font_scale"
 }

--- a/app/src/main/java/vadimerenkov/aucards/settings/Settings.kt
+++ b/app/src/main/java/vadimerenkov/aucards/settings/Settings.kt
@@ -5,11 +5,13 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.map
 import vadimerenkov.aucards.R
 import vadimerenkov.aucards.settings.Keys.BRIGHTNESS_STRING
 import vadimerenkov.aucards.settings.Keys.LANDSCAPE_STRING
+import vadimerenkov.aucards.settings.Keys.FONT_SCALE_STRING
 import vadimerenkov.aucards.settings.Keys.RINGTONE_URI
 import vadimerenkov.aucards.settings.Keys.SOUND_STRING
 import vadimerenkov.aucards.settings.Keys.THEME_STRING
@@ -53,10 +55,14 @@ class Settings(
 		.map { settings ->
 			settings[booleanPreferencesKey(SOUND_STRING)]
 		}
-	val soundUri = dataStore.data
-		.map { settings ->
-			settings[stringPreferencesKey(RINGTONE_URI)]
-		}
+        val soundUri = dataStore.data
+                .map { settings ->
+                        settings[stringPreferencesKey(RINGTONE_URI)]
+                }
+        val fontScale = dataStore.data
+                .map { settings ->
+                        settings[floatPreferencesKey(FONT_SCALE_STRING)]
+                }
 
 	suspend fun saveStringSettings(key: String, value: String) {
 		val key = stringPreferencesKey(key)
@@ -65,10 +71,17 @@ class Settings(
 		}
 	}
 
-	suspend fun saveBoolSettings(key: String, value: Boolean) {
-		val key = booleanPreferencesKey(key)
-		dataStore.edit { settings ->
-			settings[key] = value
-		}
-	}
+        suspend fun saveBoolSettings(key: String, value: Boolean) {
+                val key = booleanPreferencesKey(key)
+                dataStore.edit { settings ->
+                        settings[key] = value
+                }
+        }
+
+        suspend fun saveFloatSettings(key: String, value: Float) {
+                val key = floatPreferencesKey(key)
+                dataStore.edit { settings ->
+                        settings[key] = value
+                }
+        }
 }

--- a/app/src/main/java/vadimerenkov/aucards/ui/SettingsViewModel.kt
+++ b/app/src/main/java/vadimerenkov/aucards/ui/SettingsViewModel.kt
@@ -25,6 +25,7 @@ import vadimerenkov.aucards.data.Aucard
 import vadimerenkov.aucards.data.AucardsDatabase
 import vadimerenkov.aucards.settings.Keys.BRIGHTNESS_STRING
 import vadimerenkov.aucards.settings.Keys.LANDSCAPE_STRING
+import vadimerenkov.aucards.settings.Keys.FONT_SCALE_STRING
 import vadimerenkov.aucards.settings.Keys.RINGTONE_URI
 import vadimerenkov.aucards.settings.Keys.SOUND_STRING
 import vadimerenkov.aucards.settings.Keys.THEME_STRING
@@ -49,20 +50,22 @@ class SettingsViewModel(
 		.onEach {
 			val landscape = settings.landscape.first() ?: false
 			val brightness = settings.brightness.first() ?: false
-			val playSound = settings.playSound.first() ?: false
-			val ringtoneUri = settings.soundUri.first()?.toUri()
-			val theme = readThemeSetting()
-			val language = readLanguageSetting()
-			state.update { it.copy(
-				theme = theme,
-				isMaxBrightness = brightness,
-				isLandscapeMode = landscape,
-				language = language,
-				playSound = playSound,
-				ringtoneUri = ringtoneUri
-			) }
-		}
-		.launchIn(viewModelScope)
+                        val playSound = settings.playSound.first() ?: false
+                        val ringtoneUri = settings.soundUri.first()?.toUri()
+                        val fontScale = settings.fontScale.first() ?: 1f
+                        val theme = readThemeSetting()
+                        val language = readLanguageSetting()
+                        state.update { it.copy(
+                                theme = theme,
+                                isMaxBrightness = brightness,
+                                isLandscapeMode = landscape,
+                                language = language,
+                                playSound = playSound,
+                                ringtoneUri = ringtoneUri,
+                                fontScale = fontScale
+                        ) }
+                }
+                .launchIn(viewModelScope)
 
 	val settingsState = state
 		.stateIn(
@@ -169,14 +172,23 @@ class SettingsViewModel(
 		}
 	}
 
-	fun saveSoundSetting(playSound: Boolean) {
-		viewModelScope.launch {
-			settings.saveBoolSettings(
-				key = SOUND_STRING,
-				value = playSound
-			)
-		}
-	}
+        fun saveSoundSetting(playSound: Boolean) {
+                viewModelScope.launch {
+                        settings.saveBoolSettings(
+                                key = SOUND_STRING,
+                                value = playSound
+                        )
+                }
+        }
+
+        fun saveFontScaleSetting(scale: Float) {
+                viewModelScope.launch {
+                        settings.saveFloatSettings(
+                                key = FONT_SCALE_STRING,
+                                value = scale
+                        )
+                }
+        }
 
 	fun saveSoundUri(uri: Uri) {
 		viewModelScope.launch {
@@ -266,13 +278,14 @@ class SettingsViewModel(
 }
 
 data class SettingsState(
-	val theme: Theme = Theme.DEVICE,
-	val isMaxBrightness: Boolean = false,
-	val isLandscapeMode: Boolean = false,
-	val playSound: Boolean = false,
-	val ringtoneUri: Uri? = null,
-	val language: Language = Language.ENGLISH,
-	val isDbEmpty: Boolean = true
+        val theme: Theme = Theme.DEVICE,
+        val isMaxBrightness: Boolean = false,
+        val isLandscapeMode: Boolean = false,
+        val playSound: Boolean = false,
+        val ringtoneUri: Uri? = null,
+        val language: Language = Language.ENGLISH,
+        val isDbEmpty: Boolean = true,
+        val fontScale: Float = 1f
 )
 
 class InvalidSettingsException(setting: Any): Exception() {

--- a/app/src/main/java/vadimerenkov/aucards/ui/theme/Theme.kt
+++ b/app/src/main/java/vadimerenkov/aucards/ui/theme/Theme.kt
@@ -8,8 +8,11 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 
 private val lightScheme = lightColorScheme(
 	primary = primaryLight,
@@ -253,10 +256,11 @@ val unspecified_scheme = ColorFamily(
 
 @Composable
 fun AucardsTheme(
-	darkTheme: Boolean = isSystemInDarkTheme(),
-	// Dynamic color is available on Android 12+
-	dynamicColor: Boolean = false,
-	content: @Composable() () -> Unit
+        darkTheme: Boolean = isSystemInDarkTheme(),
+        // Dynamic color is available on Android 12+
+        dynamicColor: Boolean = false,
+        fontScale: Float = 1f,
+        content: @Composable() () -> Unit
 ) {
 	val colorScheme = when {
 		dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
@@ -268,10 +272,15 @@ fun AucardsTheme(
 		else -> lightScheme
 	}
 
-	MaterialTheme(
-		colorScheme = colorScheme,
-		typography = AppTypography,
-		content = content
-	)
+        val currentDensity = LocalDensity.current
+        CompositionLocalProvider(
+                LocalDensity provides Density(currentDensity.density, fontScale)
+        ) {
+                MaterialTheme(
+                        colorScheme = colorScheme,
+                        typography = AppTypography,
+                        content = content
+                )
+        }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,10 @@
     <string name="choose_ringtone">Choose a ringtone</string>
     <string name="pause">Pause</string>
     <string name="play">Play</string>
+    <string name="font_size">Font size</string>
+    <string name="small">Small</string>
+    <string name="medium">Medium</string>
+    <string name="large">Large</string>
     <plurals name="delete_confirmation">
         <item quantity="one">Are you sure you want to delete this card?</item>
         <item quantity="other">Are you sure you want to delete %s cards?</item>


### PR DESCRIPTION
## Summary
- allow users to choose small, medium, or large text size in settings
- persist font scale in DataStore and apply it app-wide
- scale typography through LocalDensity for consistent font sizing

## Testing
- `sh gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb540d10b88328a963c3604b09bd22